### PR TITLE
feat: add optionTypeText for custom help type labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Extensions:
     -   `value` - maximal allowed value  
     :warning: - does not limit defaults
 
--   `.optionTypeText(optionTypeText: string)` - defines option type text to be displayed in `help` command
+-   `.optionTypeText(optionTypeText: string)` - define custom help type labels to customise option help text displayed when using the `help` command
     -   `optionTypeText` - option type text to be displayed
     The default option type text is replaced e.g. declaring `.optionTypeText('opt-val')` results in `--opt number` becoming`--opt opt-val`.
     This is useful with `.enum()` options that have a large number of enum values.  

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ run([echo], {
 - [`desc`](#options-desc)
 - [`default`](#options-default)
 - [`hidden`](#options-hidden)
+- [`optionTypeText`](#options-optionTypeText)
 
   
 [**`run`**](#run)
@@ -242,6 +243,11 @@ Extensions:
 -   `.max(value: number)` - specified maximal allowed value for numbers  
     -   `value` - maximal allowed value  
     :warning: - does not limit defaults
+
+-   `.optionTypeText(optionTypeText: string)` - defines option type text to be displayed in `help` command
+    -   `optionTypeText` - option type text to be displayed
+    The default option type text is replaced e.g. declaring `.optionTypeText('opt-val')` results in `--opt number` becoming`--opt opt-val`.
+    This is useful with `.enum()` options that have a large number of enum values.  
 
 ### Creating handlers
 

--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -117,48 +117,52 @@ export type BroCliEventType = BroCliEvent['type'];
 const getOptionTypeText = (option: BuilderConfig) => {
 	let result = '';
 
-	switch (option.type) {
-		case 'boolean':
-			result = '';
-			break;
-		case 'number': {
-			if ((option.minVal ?? option.maxVal) !== undefined) {
-				let text = '';
+	if (option.optionTypeText) {
+		result = option.optionTypeText;
+	} else {
+		switch (option.type) {
+			case 'boolean':
+				result = '';
+				break;
+			case 'number': {
+				if ((option.minVal ?? option.maxVal) !== undefined) {
+					let text = '';
 
-				if (option.isInt) text = text + `integer `;
+					if (option.isInt) text = text + `integer `;
 
-				if (option.minVal !== undefined) text = text + `[${option.minVal};`;
-				else text = text + `(∞;`;
+					if (option.minVal !== undefined) text = text + `[${option.minVal};`;
+					else text = text + `(∞;`;
 
-				if (option.maxVal !== undefined) text = text + `${option.maxVal}]`;
-				else text = text + `∞)`;
+					if (option.maxVal !== undefined) text = text + `${option.maxVal}]`;
+					else text = text + `∞)`;
 
-				result = text;
+					result = text;
+					break;
+				}
+
+				if (option.isInt) {
+					result = 'integer';
+					break;
+				}
+
+				result = 'number';
 				break;
 			}
+			case 'string': {
+				if (option.enumVals) {
+					result = '[ ' + option.enumVals.join(' | ') + ' ]';
+					break;
+				}
 
-			if (option.isInt) {
-				result = 'integer';
+				result = 'string';
 				break;
 			}
-
-			result = 'number';
-			break;
-		}
-		case 'string': {
-			if (option.enumVals) {
-				result = '[ ' + option.enumVals.join(' | ') + ' ]';
+			case 'positional': {
+				result = `${option.isRequired ? '<' : '['}${option.enumVals ? option.enumVals.join('|') : option.name}${
+					option.isRequired ? '>' : ']'
+				}`;
 				break;
 			}
-
-			result = 'string';
-			break;
-		}
-		case 'positional': {
-			result = `${option.isRequired ? '<' : '['}${option.enumVals ? option.enumVals.join('|') : option.name}${
-				option.isRequired ? '>' : ']'
-			}`;
-			break;
 		}
 	}
 

--- a/src/option-builder.ts
+++ b/src/option-builder.ts
@@ -16,6 +16,7 @@ export type BuilderConfig<TType extends OptionType = OptionType> = {
 	minVal?: number;
 	maxVal?: number;
 	enumVals?: [string, ...string[]];
+	optionTypeText?: string;
 };
 
 export type ProcessedBuilderConfig = {
@@ -30,6 +31,7 @@ export type ProcessedBuilderConfig = {
 	minVal?: number;
 	maxVal?: number;
 	enumVals?: [string, ...string[]];
+	optionTypeText?: string;
 };
 
 export type BuilderConfigLimited = BuilderConfig & {
@@ -184,6 +186,19 @@ export class OptionBuilderBase<
 		const config = this.config();
 
 		return new OptionBuilderBase({ ...config, description }) as any;
+	}
+
+	public optionTypeText<TOptionTypeText extends string>(optionTypeText: TOptionTypeText): Omit<
+		OptionBuilderBase<
+			TBuilderConfig,
+			TOutput,
+			TOmit | 'optionTypeText'
+		>,
+		TOmit | 'optionTypeText'
+	> {
+		const config = this.config();
+
+		return new OptionBuilderBase({ ...config, optionTypeText }) as any;
 	}
 
 	public hidden(): Omit<

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1932,7 +1932,7 @@ describe('Globals tests', (it) => {
 describe('Type tests', (it) => {
 	const generateOps = {
 		dialect: string().alias('-d', '-dlc').desc('Database dialect [pg, mysql, sqlite]').enum('pg', 'mysql', 'sqlite')
-			.required(),
+			.optionTypeText('dialect').required(),
 		schema: string('schema').alias('s').desc('Path to a schema file or folder'),
 		out: string().alias('o').desc("Output folder, 'drizzle' by default"),
 		name: string().alias('n').desc('Migration file name'),


### PR DESCRIPTION
Add .optionTypeText() on the option builder so help can show a short label instead of the default (e.g. full enum lists). getOptionTypeText uses the override when set, otherwise keeps existing behavior.

Document in README; exercise in type tests for the dialect option.